### PR TITLE
TD-4808: prevent sz_puma_cloudwatch from emitting unneeded metrics

### DIFF
--- a/lib/puma_cloudwatch/metrics/parser.rb
+++ b/lib/puma_cloudwatch/metrics/parser.rb
@@ -1,6 +1,8 @@
 class PumaCloudwatch::Metrics
   class Parser
-    METRICS = [:backlog, :running, :pool_capacity, :max_threads]
+    # METRICS = [:backlog, :running, :pool_capacity, :max_threads]
+    # SecZetta is only using pool_capacity and max_threads metrics to calculate busy_percent
+    METRICS = [:pool_capacity, :max_threads]
 
     def initialize(data)
       @data = data


### PR DESCRIPTION
Our ECS autoscaling rules only take into account the pool_capacity and max_threads metrics emitted from the puma-cloudwatch gem. puma-cloudwatch also emits backlog and running metrics, which are not currently being used.  Every metric we send is $0.30/month * 2 apps (suite & portal) * 10 environments minimum, plus about $75/month for all the PUTs of the metrics. We can save about $150/month by eliminating sending those metrics we don’t need.

Fork puma-cloudwatch into sz_puma_cloudwatch, and eliminate sending backlog and running metrics.

This change removes the backlog and running metrics.