### PR TITLE
Add PUMA_CLOUDWATCH_AWS_REGION

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ PUMA\_CLOUDWATCH\_DIMENSION\_VALUE | CloudWatch metric dimension value | puma
 PUMA\_CLOUDWATCH\_ENABLED | Enables sending of the data to CloudWatch. | (unset)
 PUMA\_CLOUDWATCH\_FREQUENCY | How often to send data to CloudWatch in seconds. | 60
 PUMA\_CLOUDWATCH\_NAMESPACE | CloudWatch metric namespace | WebServer
+PUMA\_CLOUDWATCH\_AWS\_REGION | CloudWatch metric AWS region | (unset)
 PUMA\_CLOUDWATCH\_MUTE\_START\_MESSAGE | Mutes the "puma-cloudwatch plugin" startup message | (unset)
 
 ### Sum and Frequency Normalization

--- a/lib/puma_cloudwatch/metrics/sender.rb
+++ b/lib/puma_cloudwatch/metrics/sender.rb
@@ -18,6 +18,7 @@ class PumaCloudwatch::Metrics
       @dimension_value = ENV['PUMA_CLOUDWATCH_DIMENSION_VALUE'] || "puma"
       @frequency = Integer(ENV['PUMA_CLOUDWATCH_FREQUENCY'] || 60)
       @enabled = ENV['PUMA_CLOUDWATCH_ENABLED'] || false
+      @region = ENV['PUMA_CLOUDWATCH_AWS_REGION']
     end
 
     def call
@@ -103,7 +104,12 @@ class PumaCloudwatch::Metrics
     end
 
     def cloudwatch
-      @cloudwatch ||= Aws::CloudWatch::Client.new
+      @cloudwatch ||= if @region.present?
+                        Aws::CloudWatch::Client.new(region: @region)
+                      else
+                        Aws::CloudWatch::Client.new
+                      end
+
     rescue Aws::Errors::MissingRegionError => e
       # Happens when:
       #   1. ~/.aws/config is not also setup locally


### PR DESCRIPTION
I'm working on an app that has resources in both us-east-1 and us-east-2. I'd like to use puma-cloudwatch, but I don't want to set AWS_REGION since we have different functions of the app accessing different regions.

This PR allows users of puma-cloudwatch to set region in an ENV var that will only be used by puma-cloudwatch. Using
PUMA_CLOUDWATCH_AWS_REGION instead of AWS_REGION means that other calls to Aws libraries within the same process can rely on AWS_REGION
being set to another value (ex: us-east-1 instead of us-east-2)