### PR TITLE
http tcp port support also

### DIFF
--- a/lib/puma_cloudwatch/metrics/fetcher.rb
+++ b/lib/puma_cloudwatch/metrics/fetcher.rb
@@ -1,21 +1,43 @@
 require "json"
 require "socket"
+require "net/http"
+require "uri"
 
 class PumaCloudwatch::Metrics
   class Fetcher
     def initialize(options={})
       @control_url = options[:control_url]
       @control_auth_token = options[:control_auth_token]
+      if ENV['PUMA_CLOUDWATCH_DEBUG']
+        puts "puma control_url #{@control_url}"
+        puts "puma control_auth_token #{@control_auth_token}"
+      end
     end
 
     def call
       body = with_retries do
-        read_socket
+        read_data
       end
       JSON.parse(body.split("\n").last) # stats
     end
 
   private
+    def read_data
+      if @control_url.start_with?("unix://")
+        read_socket
+      else # starts with tcp://
+        read_http
+      end
+    end
+
+    def read_http
+      http_url = @control_url.sub('tcp://', 'http://')
+      url = "#{http_url}/stats?token=#{@control_auth_token}"
+      uri = URI.parse(url)
+      resp = Net::HTTP.get_response(uri)
+      resp.body
+    end
+
     def read_socket
       Socket.unix(@control_url.gsub('unix://', '')) do |socket|
         socket.print("GET /stats?token=#{@control_auth_token} HTTP/1.0\r\n\r\n")


### PR DESCRIPTION
Support for tcp as well as socket

config/puma.rb

```ruby
activate_control_app "tcp://127.0.0.1:9293"
plugin :cloudwatch
```
