### PR TITLE
Add `busy_threads` statistic

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ Or if you need to set multiple dimensions, you could use something like:
 
 Then you can get metrics for your `demo-web-puma` app. List of metrics:
 
+* busy_threads: "wholistic" stat reflecting the overall current state of work to be done and the capacity to do it.
 * pool_capacity: the number of requests that the server is capable of taking right now.
-* max_threads:  preconfigured maximum number of worker threads.
+* max_threads: preconfigured maximum number of worker threads.
 * running: the number of running threads (spawned threads) for any Puma worker.
 * backlog: the number of connections in that worker's "todo" set waiting for a worker thread.
 

--- a/lib/puma_cloudwatch/metrics/parser.rb
+++ b/lib/puma_cloudwatch/metrics/parser.rb
@@ -1,6 +1,6 @@
 class PumaCloudwatch::Metrics
   class Parser
-    METRICS = [:backlog, :running, :pool_capacity, :max_threads]
+    METRICS = [:backlog, :busy_threads, :running, :pool_capacity, :max_threads]
 
     def initialize(data)
       @data = data
@@ -14,6 +14,7 @@ class PumaCloudwatch::Metrics
     # Build this structure:
     #
     #     [{:backlog=>[0, 0],
+    #     :busy_threads=>[0, 0],
     #     :running=>[0, 0],
     #     :pool_capacity=>[16, 16],
     #     :max_threads=>[16, 16]}]

--- a/lib/puma_cloudwatch/metrics/sender.rb
+++ b/lib/puma_cloudwatch/metrics/sender.rb
@@ -60,13 +60,18 @@ class PumaCloudwatch::Metrics
     # Output example:
     #
     #   [{:metric_name=>"backlog",
-    #     :statistic_values=>{:sample_count=>2, :sum=>0, :minimum=>0, :maximum=>0}},
+    #     :statistic_values=>{:sample_count=>2, :sum=>0, :minimum=>0, :maximum=>0},
+    #     :storage_resolution=>60},
     #   {:metric_name=>"running",
-    #     :statistic_values=>{:sample_count=>2, :sum=>0, :minimum=>0, :maximum=>0}},
+    #     :statistic_values=>{:sample_count=>2, :sum=>0, :minimum=>0, :maximum=>0},
+    #     :storage_resolution=>60},
     #   {:metric_name=>"pool_capacity",
-    #     :statistic_values=>{:sample_count=>2, :sum=>32, :minimum=>16, :maximum=>16}},
+    #     :statistic_values=>{:sample_count=>2, :sum=>32, :minimum=>16, :maximum=>16},
+    #     :storage_resolution=>60},
     #   {:metric_name=>"max_threads",
-    #     :statistic_values=>{:sample_count=>2, :sum=>32, :minimum=>16, :maximum=>16}}]
+    #     :statistic_values=>{:sample_count=>2, :sum=>32, :minimum=>16, :maximum=>16},
+    #     :storage_resolution=>60
+    #   }]
     #
     # Resources:
     # pool_capcity and max_threads are the important metrics

--- a/lib/puma_cloudwatch/metrics/sender.rb
+++ b/lib/puma_cloudwatch/metrics/sender.rb
@@ -54,12 +54,16 @@ class PumaCloudwatch::Metrics
     #
     #     [{:backlog=>[0, 0],
     #     :running=>[0, 0],
+    #     :busy_threads=>[0, 0],
     #     :pool_capacity=>[16, 16],
     #     :max_threads=>[16, 16]}]
     #
     # Output example:
     #
     #   [{:metric_name=>"backlog",
+    #     :statistic_values=>{:sample_count=>2, :sum=>0, :minimum=>0, :maximum=>0},
+    #     :storage_resolution=>60},
+    #   {:metric_name=>"busy_threads",
     #     :statistic_values=>{:sample_count=>2, :sum=>0, :minimum=>0, :maximum=>0},
     #     :storage_resolution=>60},
     #   {:metric_name=>"running",

--- a/spec/puma_cloudwatch/metrics/fetcher_spec.rb
+++ b/spec/puma_cloudwatch/metrics/fetcher_spec.rb
@@ -1,19 +1,3 @@
-# RSpec.describe PumaCloudwatch::Metrics::Fetcher do
-#   subject(:fetcher) { described_class.new(control_url: '', control_auth_token: '') }
-
-#   describe "fetcher" do
-#     it "call" do
-#       fake_data = {"fake" => "data"}
-#       json_data = JSON.dump(fake_data)
-#       allow(Socket).to receive(:unix).and_return(json_data)
-
-#       stats = fetcher.call
-#       expect(stats).to eq(fake_data)
-#     end
-#   end
-# end
-
-
 RSpec.describe PumaCloudwatch::Metrics::Fetcher do
   subject(:fetcher) { described_class.new(control_url: 'unix:///tmp/fake.sock', control_auth_token: '') }
 

--- a/spec/puma_cloudwatch/metrics/fetcher_spec.rb
+++ b/spec/puma_cloudwatch/metrics/fetcher_spec.rb
@@ -1,11 +1,32 @@
+# RSpec.describe PumaCloudwatch::Metrics::Fetcher do
+#   subject(:fetcher) { described_class.new(control_url: '', control_auth_token: '') }
+
+#   describe "fetcher" do
+#     it "call" do
+#       fake_data = {"fake" => "data"}
+#       json_data = JSON.dump(fake_data)
+#       allow(Socket).to receive(:unix).and_return(json_data)
+
+#       stats = fetcher.call
+#       expect(stats).to eq(fake_data)
+#     end
+#   end
+# end
+
+
 RSpec.describe PumaCloudwatch::Metrics::Fetcher do
-  subject(:fetcher) { described_class.new(control_url: '', control_auth_token: '') }
+  subject(:fetcher) { described_class.new(control_url: 'unix:///tmp/fake.sock', control_auth_token: '') }
 
   describe "fetcher" do
-    it "call" do
-      fake_data = {"fake" => "data"}
-      json_data = JSON.dump(fake_data)
-      allow(Socket).to receive(:unix).and_return(json_data)
+    it "calls and parses the socket response" do
+      fake_data = { "fake" => "data" }
+      response_body = "HTTP/1.0 200 OK\r\n\r\n#{JSON.dump(fake_data)}"
+
+      mock_socket = double("socket")
+      allow(mock_socket).to receive(:print)
+      allow(mock_socket).to receive(:read).and_return(response_body)
+
+      allow(Socket).to receive(:unix).and_yield(mock_socket)
 
       stats = fetcher.call
       expect(stats).to eq(fake_data)

--- a/spec/puma_cloudwatch/metrics/parser_spec.rb
+++ b/spec/puma_cloudwatch/metrics/parser_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe PumaCloudwatch::Metrics::Parser do
     let(:data) do
       {"started_at"=>"2019-09-16T19:20:12Z",
        "backlog"=>0,
+       "busy_threads"=>0,
        "running"=>16,
        "pool_capacity"=>8,
        "max_threads"=>16}
@@ -15,6 +16,7 @@ RSpec.describe PumaCloudwatch::Metrics::Parser do
       expect(results).to be_a(Array)
       expect(results).to eq(
         [{:backlog=>[0],
+          :busy_threads=>[0],
           :running=>[16],
           :pool_capacity=>[8],
           :max_threads=>[16]}]
@@ -69,7 +71,7 @@ RSpec.describe PumaCloudwatch::Metrics::Parser do
               "booted"=>true,
               "last_checkin"=>"2019-09-16T16:12:41Z",
               "last_status"=>
-               {"backlog"=>0, "running"=>1, "pool_capacity"=>16, "max_threads"=>16}},
+               {"backlog"=>0, "busy_threads"=>0, "running"=>1, "pool_capacity"=>16, "max_threads"=>16}},
              {"started_at"=>"2019-09-16T16:12:11Z",
               "pid"=>19836,
               "index"=>1,
@@ -78,6 +80,7 @@ RSpec.describe PumaCloudwatch::Metrics::Parser do
               "last_checkin"=>"2019-09-16T16:12:41Z",
               "last_status"=>
                {"backlog"=>0,
+                "busy_threads"=>0,
                 "running"=>16,
                 "pool_capacity"=>8,
                 "max_threads"=>16}}]}
@@ -89,6 +92,7 @@ RSpec.describe PumaCloudwatch::Metrics::Parser do
         expect(results).to be_a(Array)
         expect(results).to eq(
           [{:backlog=>[0, 0],
+            :busy_threads=>[0, 0],
             :running=>[1, 16],
             :pool_capacity=>[16, 8],
             :max_threads=>[16, 16]}]

--- a/spec/puma_cloudwatch/metrics/sender_spec.rb
+++ b/spec/puma_cloudwatch/metrics/sender_spec.rb
@@ -14,17 +14,25 @@ RSpec.describe PumaCloudwatch::Metrics::Sender do
         data = sender.metric_data
         expect(data).to eq(
           [{:metric_name=>"backlog",
-            :dimensions=>[{:name=>"App", :value=>"demo-puma"}],
-            :statistic_values=>{:sample_count=>1, :sum=>0, :minimum=>0, :maximum=>0}},
+            :dimensions=>[{:name=>"App", :value=>"puma"}],
+            :statistic_values=>{:sample_count=>1, :sum=>0, :minimum=>0, :maximum=>0},
+            :storage_resolution=>60
+          },
            {:metric_name=>"running",
-            :dimensions=>[{:name=>"App", :value=>"demo-puma"}],
-            :statistic_values=>{:sample_count=>1, :sum=>16, :minimum=>16, :maximum=>16}},
+            :dimensions=>[{:name=>"App", :value=>"puma"}],
+            :statistic_values=>{:sample_count=>1, :sum=>16, :minimum=>16, :maximum=>16},
+            :storage_resolution=>60
+          },
            {:metric_name=>"pool_capacity",
-            :dimensions=>[{:name=>"App", :value=>"demo-puma"}],
-            :statistic_values=>{:sample_count=>1, :sum=>8, :minimum=>8, :maximum=>8}},
+            :dimensions=>[{:name=>"App", :value=>"puma"}],
+            :statistic_values=>{:sample_count=>1, :sum=>8, :minimum=>8, :maximum=>8},
+            :storage_resolution=>60
+          },
            {:metric_name=>"max_threads",
-            :dimensions=>[{:name=>"App", :value=>"demo-puma"}],
-            :statistic_values=>{:sample_count=>1, :sum=>16, :minimum=>16, :maximum=>16}}]
+            :dimensions=>[{:name=>"App", :value=>"puma"}],
+            :statistic_values=>{:sample_count=>1, :sum=>16, :minimum=>16, :maximum=>16},
+            :storage_resolution=>60
+          }]
         )
       end
 
@@ -49,17 +57,25 @@ RSpec.describe PumaCloudwatch::Metrics::Sender do
         data = sender.metric_data
         expect(data).to eq(
           [{:metric_name=>"backlog",
-            :dimensions=>[{:name=>"App", :value=>"demo-puma"}],
-            :statistic_values=>{:sample_count=>2, :sum=>0, :minimum=>0, :maximum=>0}},
+            :dimensions=>[{:name=>"App", :value=>"puma"}],
+            :statistic_values=>{:sample_count=>2, :sum=>0, :minimum=>0, :maximum=>0},
+            :storage_resolution=>60
+          },
            {:metric_name=>"running",
-            :dimensions=>[{:name=>"App", :value=>"demo-puma"}],
-            :statistic_values=>{:sample_count=>2, :sum=>0, :minimum=>0, :maximum=>0}},
+            :dimensions=>[{:name=>"App", :value=>"puma"}],
+            :statistic_values=>{:sample_count=>2, :sum=>0, :minimum=>0, :maximum=>0},
+            :storage_resolution=>60
+          },
            {:metric_name=>"pool_capacity",
-            :dimensions=>[{:name=>"App", :value=>"demo-puma"}],
-            :statistic_values=>{:sample_count=>2, :sum=>32, :minimum=>16, :maximum=>16}},
+            :dimensions=>[{:name=>"App", :value=>"puma"}],
+            :statistic_values=>{:sample_count=>2, :sum=>32, :minimum=>16, :maximum=>16},
+            :storage_resolution=>60
+          },
            {:metric_name=>"max_threads",
-            :dimensions=>[{:name=>"App", :value=>"demo-puma"}],
-            :statistic_values=>{:sample_count=>2, :sum=>32, :minimum=>16, :maximum=>16}}]
+            :dimensions=>[{:name=>"App", :value=>"puma"}],
+            :statistic_values=>{:sample_count=>2, :sum=>32, :minimum=>16, :maximum=>16},
+            :storage_resolution=>60
+          }]
         )
       end
 

--- a/spec/puma_cloudwatch/metrics/sender_spec.rb
+++ b/spec/puma_cloudwatch/metrics/sender_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe PumaCloudwatch::Metrics::Sender do
     context "metrics filled out" do
       let(:metrics) {
         [{:backlog=>[0],
+        :busy_threads=>[0],
         :running=>[16],
         :pool_capacity=>[8],
         :max_threads=>[16]}]
@@ -14,6 +15,11 @@ RSpec.describe PumaCloudwatch::Metrics::Sender do
         data = sender.metric_data
         expect(data).to eq(
           [{:metric_name=>"backlog",
+            :dimensions=>[{:name=>"App", :value=>"puma"}],
+            :statistic_values=>{:sample_count=>1, :sum=>0, :minimum=>0, :maximum=>0},
+            :storage_resolution=>60
+          },
+           {:metric_name=>"busy_threads",
             :dimensions=>[{:name=>"App", :value=>"puma"}],
             :statistic_values=>{:sample_count=>1, :sum=>0, :minimum=>0, :maximum=>0},
             :storage_resolution=>60
@@ -48,6 +54,7 @@ RSpec.describe PumaCloudwatch::Metrics::Sender do
     context "metrics filled out" do
       let(:metrics) {
         [{:backlog=>[0, 0],
+        :busy_threads=>[0, 0],
         :running=>[0, 0],
         :pool_capacity=>[16, 16],
         :max_threads=>[16, 16]}]
@@ -57,6 +64,11 @@ RSpec.describe PumaCloudwatch::Metrics::Sender do
         data = sender.metric_data
         expect(data).to eq(
           [{:metric_name=>"backlog",
+            :dimensions=>[{:name=>"App", :value=>"puma"}],
+            :statistic_values=>{:sample_count=>2, :sum=>0, :minimum=>0, :maximum=>0},
+            :storage_resolution=>60
+          },
+           {:metric_name=>"busy_threads",
             :dimensions=>[{:name=>"App", :value=>"puma"}],
             :statistic_values=>{:sample_count=>2, :sum=>0, :minimum=>0, :maximum=>0},
             :storage_resolution=>60


### PR DESCRIPTION
This pull request introduces the `busy_threads` metric to the Puma Cloudwatch integration, updates the metric parsing and sending logic, and adjusts the corresponding tests to accommodate the new metric.

### Metrics Addition:
* Added `busy_threads` to the list of metrics in `lib/puma_cloudwatch/metrics/parser.rb`.
* Updated the example structure in the `call` method documentation to include `busy_threads` in `lib/puma_cloudwatch/metrics/parser.rb` and `lib/puma_cloudwatch/metrics/sender.rb`. [[1]](diffhunk://#diff-80bce4fa3889b193f5c934da470158c27e1c7aedc826b5ac25c241dd2c2fcc1aR17) [[2]](diffhunk://#diff-3d3adbe51c89117bf83125b917db58fa9f51862fa095b9342c3a66e225769d62R57-R78)

### Documentation Update:
* Added a description for the `busy_threads` metric in the `README.md` file.

### Test Adjustments:
* Modified `spec/puma_cloudwatch/metrics/fetcher_spec.rb` to use a mock socket and updated the test description.
* Updated `spec/puma_cloudwatch/metrics/parser_spec.rb` to include `busy_threads` in the test data and expectations. [[1]](diffhunk://#diff-eb17f0151545bafa7f45544a2012c097f457610e671a6238debb04537b4a4149R8) [[2]](diffhunk://#diff-eb17f0151545bafa7f45544a2012c097f457610e671a6238debb04537b4a4149R19) [[3]](diffhunk://#diff-eb17f0151545bafa7f45544a2012c097f457610e671a6238debb04537b4a4149L72-R74) [[4]](diffhunk://#diff-eb17f0151545bafa7f45544a2012c097f457610e671a6238debb04537b4a4149R83) [[5]](diffhunk://#diff-eb17f0151545bafa7f45544a2012c097f457610e671a6238debb04537b4a4149R95)
* Adjusted `spec/puma_cloudwatch/metrics/sender_spec.rb` to validate the inclusion of `busy_threads` in the metric data and its storage resolution. [[1]](diffhunk://#diff-406b819f2d1223c42d8c8889207db62a56873f69b693a4cefae8aaaea801564dR8) [[2]](diffhunk://#diff-406b819f2d1223c42d8c8889207db62a56873f69b693a4cefae8aaaea801564dL17-R41) [[3]](diffhunk://#diff-406b819f2d1223c42d8c8889207db62a56873f69b693a4cefae8aaaea801564dR57) [[4]](diffhunk://#diff-406b819f2d1223c42d8c8889207db62a56873f69b693a4cefae8aaaea801564dL52-R90)